### PR TITLE
Require prezent-grid 0.5.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "require": {
         "php": "~5.5",
         "ext-intl": "*",
-        "prezent/grid": "~0.4.0",
+        "prezent/grid": "~0.5.0",
         "symfony/framework-bundle": "~2.3|~3.0",
         "symfony/translation": "~2.3|~3.0",
         "symfony/twig-bundle": "~2.3|~3.0"


### PR DESCRIPTION
Require prezent-grid 0.5.0 instead of 0.4.0, due to new tag.
