### PR TITLE
Updated service config for symfony 3

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -25,10 +25,9 @@
     </parameters>
     <services>
 
-        <service id="prezent_grid.accessor" class="Symfony\Component\PropertyAccess\PropertyAccessorInterface"
-            factory-class="Symfony\Component\PropertyAccess\PropertyAccess"
-            factory-method="createPropertyAccessor"
-            public="false" />
+	<service id="prezent_grid.accessor" class="Symfony\Component\PropertyAccess\PropertyAccessorInterface">
+            <factory class="Symfony\Component\PropertyAccess\PropertyAccess" method="createPropertyAccessor" />
+        </service>
 
         <!-- Grid extensions -->
         <service id="prezent_grid.extension.core" class="%prezent_grid.extension.core.class%" public="false">


### PR DESCRIPTION
`factory-class` and `factory-method` was removed in `symfony 2.6` (http://symfony.com/doc/2.6/components/dependency_injection/factories.html), so in `symfony 3` your extension is not working, this merge fixes it.
