### PR TITLE
Add 'sort_order' variable to the sortable header view 

### DIFF
--- a/Grid/Type/SortableTypeExtension.php
+++ b/Grid/Type/SortableTypeExtension.php
@@ -6,9 +6,7 @@ use Prezent\Grid\BaseElementTypeExtension;
 use Prezent\Grid\ElementView;
 use Prezent\Grid\Extension\Core\Type\ColumnType;
 use Symfony\Component\HttpFoundation\RequestStack;
-use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 /**
  * Sortable columns
@@ -82,21 +80,23 @@ class SortableTypeExtension extends BaseElementTypeExtension
         $active = false;
         $order = 'ASC';
 
-        $field = $options['sort_field'] ?: $view->name;
+        $sortField = $options['sort_field'] ?: $view->name;
         $routeParams = $options['sort_route_parameters'] ?: $request->attributes->get('_route_params', []);
         $routeParams = array_merge($routeParams, $request->query->all());
 
-        if ($field === $request->get($options['sort_field_parameter'])) {
-            $active = $request->get($options['sort_order_parameter']);
-            $order = 'ASC' === $active ? 'DESC' : 'ASC';
+        if ($sortField === $request->get($options['sort_field_parameter'])) {
+            $active = true;
+            $currentSort = $request->get($options['sort_order_parameter']);
+            $order = 'ASC' === $currentSort ? 'DESC' : 'ASC';
         }
 
-        $routeParams[$options['sort_field_parameter']] = $field;
+        $routeParams[$options['sort_field_parameter']] = $sortField;
         $routeParams[$options['sort_order_parameter']] = $order;
 
         $view->vars['sort_route'] = $options['sort_route'] ?: $request->attributes->get('_route');
         $view->vars['sort_route_parameters'] = $routeParams;
-        $view->vars['sort_active'] = $active !== false;
+        $view->vars['sort_active'] = $active;
+        $view->vars['sort_order'] = $order;
     }
 
     /**

--- a/Grid/Type/SortableTypeExtension.php
+++ b/Grid/Type/SortableTypeExtension.php
@@ -86,8 +86,8 @@ class SortableTypeExtension extends BaseElementTypeExtension
 
         if ($sortField === $request->get($options['sort_field_parameter'])) {
             $active = true;
-            $currentSort = $request->get($options['sort_order_parameter']);
-            $order = 'ASC' === $currentSort ? 'DESC' : 'ASC';
+            $currentOrder = $request->get($options['sort_order_parameter']);
+            $order = 'ASC' === $currentOrder ? 'DESC' : 'ASC';
         }
 
         $routeParams[$options['sort_field_parameter']] = $sortField;

--- a/Resources/views/Grid/grid.html.twig
+++ b/Resources/views/Grid/grid.html.twig
@@ -7,7 +7,7 @@
     {% if sort_route is defined and sort_route_parameters is defined %}
         <a
             href="{{ path(sort_route, sort_route_parameters) }}"
-            class="prezent-grid-sortable"{% if sort_active %} data-sort-dir="{{ sort_active|lower }}"{% endif %}
+            class="prezent-grid-sortable"{% if sort_active %} data-sort-dir="{{ sort_order|lower }}"{% endif %}
         >
             {{ parent() }}
         </a>

--- a/Tests/Grid/Type/SortableTypeExtensionTest.php
+++ b/Tests/Grid/Type/SortableTypeExtensionTest.php
@@ -78,6 +78,7 @@ class SortableTypeExtensionTest extends TestCase
             ]),
             array_merge($this->defaultOptions, ['sortable' => true]),
             [
+                'sort_order' => 'ASC',
                 'sort_active' => false,
                 'sort_route' => 'my_route',
                 'sort_route_parameters' => [
@@ -97,6 +98,7 @@ class SortableTypeExtensionTest extends TestCase
             ]),
             array_merge($this->defaultOptions, ['sortable' => true]),
             [
+                'sort_order' => 'DESC',
                 'sort_active' => true,
                 'sort_route' => 'my_route',
                 'sort_route_parameters' => [
@@ -113,6 +115,7 @@ class SortableTypeExtensionTest extends TestCase
             ]),
             array_merge($this->defaultOptions, ['sortable' => true]),
             [
+                'sort_order' => 'ASC',
                 'sort_active' => false,
                 'sort_route' => 'my_route',
                 'sort_route_parameters' => [
@@ -138,6 +141,7 @@ class SortableTypeExtensionTest extends TestCase
                 'sort_order_parameter'  => 'order',
             ],
             [
+                'sort_order' => 'ASC',
                 'sort_active' => false,
                 'sort_route' => 'custom_route',
                 'sort_route_parameters' => [


### PR DESCRIPTION
Add `sort_order` variable to the sortable header view and use it to set `data-sort-dir` HTML attribute.
Setting `data-sort-dir` to `asc` or `desc` will be consistent with the CSS definitions.