### PR TITLE
Use service locator for lazy loading grid types and extensions

### DIFF
--- a/Grid/Extension/GridBundleExtension.php
+++ b/Grid/Extension/GridBundleExtension.php
@@ -4,7 +4,7 @@ namespace Prezent\GridBundle\Grid\Extension;
 
 use Prezent\Grid\Exception\InvalidArgumentException;
 use Prezent\Grid\GridExtension;
-use Symfony\Component\DependencyInjection\ContainerInterface;
+use Psr\Container\ContainerInterface;
 
 /**
  * Lazy-load grid types and element types

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -39,7 +39,7 @@
         </service>
 
         <service id="prezent_grid.extension.bundle" class="%prezent_grid.extension.bundle.class%" public="false">
-            <argument type="service" id="service_container" />
+            <argument type="service_locator" />
             <argument />
             <argument />
             <argument />

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
         "symfony/framework-bundle": "^5.0|^6.0",
         "symfony/options-resolver": "^5.0|^6.0",
         "symfony/translation": "^5.0|^6.0",
-        "symfony/twig-bundle": "^5.0|^6.0"
+        "symfony/twig-bundle": "^5.0|^6.0",
+        "psr/container": "^2.0"
     },
     "require-dev": {
         "symfony/browser-kit": "^5.0|^6.0",


### PR DESCRIPTION
I copied and adopted the code from [Symfony\Component\Form\DependencyInjection\FormPass](https://github.com/symfony/symfony/blob/4dde1619d6c65b662170a6a3cbbdc7092eeb1fa2/src/Symfony/Component/Form/DependencyInjection/FormPass.php#L52). The documentation about usage of the `register` method see here: https://symfony.com/doc/current/service_container/service_subscribers_locators.html#using-service-locators-in-compiler-passes.