### PR TITLE
Allow prezent/grid 0.14 that was already allowed for the 0.5-branch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "require": {
         "php": "^7.0|^8.0",
         "ext-intl": "*",
-        "prezent/grid": "^0.12|^0.13",
+        "prezent/grid": "^0.12|^0.13|^0.14",
         "symfony/dependency-injection": "^5.0|^6.0",
         "symfony/framework-bundle": "^5.0|^6.0",
         "symfony/options-resolver": "^5.0|^6.0",


### PR DESCRIPTION
`prezent/grid@0.14` was already allowed on the `0.5`-branch, but not for upstream. This PR allows for installing `prezent/grid@0.14` alongside the latest versions of this bundle.